### PR TITLE
预训练数据构造有误

### DIFF
--- a/create_pretraining_data.py
+++ b/create_pretraining_data.py
@@ -558,10 +558,12 @@ def create_masked_lm_predictions(tokens, masked_lm_prob,
                 # 10% of the time, replace with random word
                 else:
                     masked_token = vocab_words[rng.randint(0, len(vocab_words) - 1)]
-
+            
+            # 获取真实标签（没有'##'）
+            masked_lms.append(MaskedLmInstance(index=index, label=output_tokens[index]))
             output_tokens[index] = masked_token
 
-            masked_lms.append(MaskedLmInstance(index=index, label=tokens[index]))
+            
     assert len(masked_lms) <= num_to_predict
     masked_lms = sorted(masked_lms, key=lambda x: x.index)
 


### PR DESCRIPTION
原来的代码中，在wwm阶段，MLM任务中标签会被构造为开头带'##'的汉字，而在下游任务中这种token是没有意义的。
这就导致wwm在下游任务中其实并没有任何作用，反而伤害了模型。